### PR TITLE
Update README for installing torch_scatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ conda activate conv_onet
 ```
 **Note**: you might need to install **torch-scatter** mannually following [the official instruction](https://github.com/rusty1s/pytorch_scatter#pytorch-140):
 ```
-pip install torch-scatter==latest+cu101 -f https://pytorch-geometric.com/whl/torch-1.4.0.html
+pip install torch-scatter==2.0.4 -f https://pytorch-geometric.com/whl/torch-1.4.0+cu101.html
 ```
 
 Next, compile the extension modules.


### PR DESCRIPTION
Update the torch_scatter installation instruction according to the latest documentation and also specify the version `2.0.4` explicitly as in `environment.yaml`:
```
pip install torch-scatter==2.0.4 -f https://pytorch-geometric.com/whl/torch-1.4.0+cu101.html
```